### PR TITLE
Build full media type in ViewableWriter and sync changes to charset

### DIFF
--- a/core/src/test/java/org/eclipse/krazo/core/ViewableWriterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewableWriterTest.java
@@ -110,7 +110,7 @@ public class ViewableWriterTest {
         ViewEngine viewEngine = EasyMock.createStrictMock(ViewEngine.class);
 
         HttpServletResponse response = EasyMock.createStrictMock(HttpServletResponse.class);
-        response.setCharacterEncoding(eq("UTF-8"));
+        response.setContentType(eq("text/html;charset=UTF-8"));
         expect(response.getCharacterEncoding()).andReturn("UTF-8");
         Field responseField = writer.getClass().getDeclaredField("injectedResponse");
         responseField.setAccessible(true);
@@ -133,7 +133,7 @@ public class ViewableWriterTest {
         viewEngine.processView((ViewEngineContext) anyObject());
 
         replay(finder, request, viewEngine, response);
-        writer.writeTo(viewable, null, null, new Annotation[] {}, MediaType.WILDCARD_TYPE, map, null);
+        writer.writeTo(viewable, null, null, new Annotation[] {}, MediaType.TEXT_HTML_TYPE, map, null);
         verify(finder, request, viewEngine, response);
     }
 }


### PR DESCRIPTION
Hi @lefloh,

I experimented a lot with your changes. My initial goal was to not only sync the `charset` of the `HttpServletResponse` to the header map, but also the content type. But I failed! :cry: Looks like this is much harder than I thought and maybe even not possible at all. I'll start some discussion about this at a later time.

However, during my work I refactored the code a bit and these improvements MAY be worth integrating into your branch. 

The refactoring includes:
- We now build a full effective media type from what JAX-RS provides in the `ViewableWriter` itself AND also create the correct `Content-Type` header there. IMO it is good to do it in the `ViewableWriter` because all the view engines will benefit from getting these defaults. However, of course all engines are able to change the default by updating the header map.
- The effective media type is provided as a constructor argument to `MvcHttpServletResponse` which will then call `setContentType()` to initialize the response with this media type. Please note that calling `setContentType()` with a content type that contains a charset will internally also call `setCharacterEncoding()`.
- If either `setContentType()` or `setCharacterEncoding()` is called afterwards, the changes are synced to the headers map. This also means that the headers map is always in sync and not only if `getWriter()` is called. Please note that the content type itself will NOT be synchronized at the moment. See my comment above.

I guess that's all. Let me know what you think. 
